### PR TITLE
1.1.3 (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# CHANGELOG 1.1.3
+## Changes
+- Changes in validation errorlist
+- Changes in unauthorized HTTP Code 401 Unauthorised
+- Pocket list - Count on move/delete item
+- Pocket list - Join on rewilding to get detail
+- Pocket List - Location info on rewilding
+- Rewilding Search - Water type
+
 # CHANGELOG 1.1.2
 ## Changes
 - Removal of duplicated reference endpoint in rewilding and event in favour for one general references endpoint

--- a/internal/helpers/places.go
+++ b/internal/helpers/places.go
@@ -46,24 +46,48 @@ func GoogleGeocoding(c *gin.Context) {
 	//placesService := GooglePlacesInitialise(c)
 }
 
-func GooglePlacesGetArea(addresses []maps.AddressComponent, addressType string) string {
-	var area string
+func GooglePlacesGetArea(addresses []maps.AddressComponent, addressType string) (string, string) {
+	longName := ""
+	shortName := ""
 	for _, val := range addresses {
 		if StringInSlice(addressType, val.Types) {
-			area = val.LongName
+			shortName = val.ShortName
+			longName = val.LongName
 		}
 	}
-	return area
+	return longName, shortName
 }
 
-func GooglePlacesV1GetArea(addresses []*places.GoogleMapsPlacesV1PlaceAddressComponent, addressType string) string {
-	var area string
+func GooglePlacesToLocationArray(addresses []maps.AddressComponent) []string {
+	loc := []string{}
+	key := []string{"administrative_area_level_2", "administrative_area_level_1", "country"}
+	for _, v := range key {
+		longName, _ := GooglePlacesGetArea(addresses, v)
+		loc = append(loc, longName)
+	}
+	return loc
+}
+
+func GooglePlacesV1GetArea(addresses []*places.GoogleMapsPlacesV1PlaceAddressComponent, addressType string) (string, string) {
+	longName := ""
+	shortName := ""
 	for _, val := range addresses {
 		if StringInSlice(addressType, val.Types) {
-			area = val.LongText
+			shortName = val.ShortText
+			longName = val.LongText
 		}
 	}
-	return area
+	return longName, shortName
+}
+
+func GooglePlacesV1ToLocationArray(addresses []*places.GoogleMapsPlacesV1PlaceAddressComponent) []string {
+	loc := []string{}
+	key := []string{"administrative_area_level_1", "administrative_area_level_2", "country"}
+	for _, v := range key {
+		longName, _ := GooglePlacesV1GetArea(addresses, v)
+		loc = append(loc, longName)
+	}
+	return loc
 }
 
 func GooglePlacePhoto(c *gin.Context, photoName string) *places.GoogleMapsPlacesV1PhotoMedia {

--- a/internal/helpers/validate.go
+++ b/internal/helpers/validate.go
@@ -12,7 +12,7 @@ import (
 )
 
 func Validate(c *gin.Context, arr interface{}) error {
-	var errorList []string
+	errorList := []string{}
 	if err := c.Bind(&arr); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"code": -2, "message": "Validation error! JSON does not match", "data": errorList, "validation": "oosa_api"})
 		return err
@@ -37,7 +37,7 @@ func Validate(c *gin.Context, arr interface{}) error {
 }
 
 func ValidateForm(c *gin.Context, payload interface{}) error {
-	var errorList []string
+	errorList := []string{}
 	if err := c.Bind(payload); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"code": -2, "message": "Validation error! Form does not match", "data": errorList, "validation": "oosa_api"})
 		return err
@@ -62,7 +62,7 @@ func ValidateForm(c *gin.Context, payload interface{}) error {
 }
 
 func ValidateError(c *gin.Context, err error) error {
-	var errorList []string
+	errorList := []string{}
 	validationErrors := err.(validator.ValidationErrors)
 	for _, e := range validationErrors {
 		//translatedErr := fmt.Errorf(e.Translate(trans))

--- a/internal/middleware/AuthMiddleware.go
+++ b/internal/middleware/AuthMiddleware.go
@@ -13,7 +13,7 @@ func AuthMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		reqToken := c.Request.Header.Get("Authorization")
 		if reqToken == "" {
-			c.JSON(http.StatusBadRequest, gin.H{"message": "AUTH01-REWILDING: You are not authorized to access this resource"})
+			c.JSON(http.StatusUnauthorized, gin.H{"message": "AUTH01-REWILDING: You are not authorized to access this resource"})
 			c.Abort()
 			return
 		}
@@ -24,13 +24,13 @@ func AuthMiddleware() gin.HandlerFunc {
 		user, err := auth.VerifyToken(reqToken)
 
 		if err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"message": "AUTH02-REWILDING: You are not authorized to access this resource"})
+			c.JSON(http.StatusUnauthorized, gin.H{"message": "AUTH02-REWILDING: You are not authorized to access this resource"})
 			c.Abort()
 			return
 		}
 
 		if helpers.MongoZeroID(user.UsersId) {
-			c.JSON(http.StatusBadRequest, gin.H{"message": "AUTH03-REWILDING: You are not authorized to access this resource"})
+			c.JSON(http.StatusUnauthorized, gin.H{"message": "AUTH03-REWILDING: You are not authorized to access this resource"})
 			c.Abort()
 			return
 		}

--- a/internal/models/eventPolaroids.go
+++ b/internal/models/eventPolaroids.go
@@ -3,12 +3,12 @@ package models
 import "go.mongodb.org/mongo-driver/bson/primitive"
 
 type EventPolaroids struct {
-	EventPolaroidsId            primitive.ObjectID   `bson:"_id,omitempty" json:"event_polaroids_id"`
-	EventPolaroidsEvent         primitive.ObjectID   `bson:"event_polaroids_event,omitempty" json:"event_polaroids_event"`
-	EventPolaroidsUrl           string               `bson:"event_polaroids_url,omitempty" json:"event_polaroids_url"`
-	EventPolaroidsLat           primitive.Decimal128 `bson:"event_polaroids_lat,omitempty" json:"event_polaroids_lat"`
-	EventPolaroidsLng           primitive.Decimal128 `bson:"event_polaroids_lng,omitempty" json:"event_polaroids_lng"`
-	EventPolaroidsCreatedBy     primitive.ObjectID   `bson:"event_polaroids_created_by,omitempty" json:"event_polaroids_created_by"`
-	EventPolaroidsCreatedAt     primitive.DateTime   `bson:"event_polaroids_created_at,omitempty" json:"event_polaroids_created_at"`
-	EventPolaroidsCreatedByUser *UsersAgg            `bson:"event_polaroids_created_by_user,omitempty" json:"event_polaroids_created_by_user,omitempty"`
+	EventPolaroidsId            primitive.ObjectID `bson:"_id,omitempty" json:"event_polaroids_id"`
+	EventPolaroidsEvent         primitive.ObjectID `bson:"event_polaroids_event,omitempty" json:"event_polaroids_event"`
+	EventPolaroidsUrl           string             `bson:"event_polaroids_url,omitempty" json:"event_polaroids_url"`
+	EventPolaroidsLat           float64            `bson:"event_polaroids_lat,omitempty" json:"event_polaroids_lat"`
+	EventPolaroidsLng           float64            `bson:"event_polaroids_lng,omitempty" json:"event_polaroids_lng"`
+	EventPolaroidsCreatedBy     primitive.ObjectID `bson:"event_polaroids_created_by,omitempty" json:"event_polaroids_created_by"`
+	EventPolaroidsCreatedAt     primitive.DateTime `bson:"event_polaroids_created_at,omitempty" json:"event_polaroids_created_at"`
+	EventPolaroidsCreatedByUser *UsersAgg          `bson:"event_polaroids_created_by_user,omitempty" json:"event_polaroids_created_by_user,omitempty"`
 }

--- a/internal/models/pocketListItems.go
+++ b/internal/models/pocketListItems.go
@@ -3,11 +3,12 @@ package models
 import "go.mongodb.org/mongo-driver/bson/primitive"
 
 type PocketListItems struct {
-	PocketListItemsId        primitive.ObjectID `bson:"_id,omitempty" json:"pocket_list_items_id"`
-	PocketListItemsMst       primitive.ObjectID `bson:"pocket_list_items_mst" json:"pocket_list_items_mst,omitempty"`
-	PocketListItemsName      string             `bson:"pocket_list_items_name" json:"pocket_list_items_name,omitempty"`
-	PocketListItemsEvent     primitive.ObjectID `bson:"pocket_list_items_event,omitempty" json:"pocket_list_items_event,omitempty,omitzero"`
-	PocketListItemsRewilding primitive.ObjectID `bson:"pocket_list_items_rewilding,omitempty" json:"pocket_list_items_rewilding,omitempty"`
-	PocketListItemsDeletedAt primitive.DateTime `bson:"pocket_list_items_deleted_at,omitempty" json:"pocket_list_items_deleted_at,omitempty"`
-	PocketListItemsCreatedAt primitive.DateTime `bson:"pocket_list_items_created_at,omitempty" json:"pocket_list_items_created_at,omitempty"`
+	PocketListItemsId              primitive.ObjectID `bson:"_id,omitempty" json:"pocket_list_items_id"`
+	PocketListItemsMst             primitive.ObjectID `bson:"pocket_list_items_mst" json:"pocket_list_items_mst,omitempty"`
+	PocketListItemsName            string             `bson:"pocket_list_items_name" json:"pocket_list_items_name,omitempty"`
+	PocketListItemsEvent           primitive.ObjectID `bson:"pocket_list_items_event,omitempty" json:"pocket_list_items_event,omitempty,omitzero"`
+	PocketListItemsRewilding       primitive.ObjectID `bson:"pocket_list_items_rewilding,omitempty" json:"pocket_list_items_rewilding,omitempty"`
+	PocketListItemsDeletedAt       primitive.DateTime `bson:"pocket_list_items_deleted_at,omitempty" json:"pocket_list_items_deleted_at,omitempty"`
+	PocketListItemsCreatedAt       primitive.DateTime `bson:"pocket_list_items_created_at,omitempty" json:"pocket_list_items_created_at,omitempty"`
+	PocketListItemsRewildingDetail *Rewilding         `bson:"pocket_list_items_rewilding_detail,omitempty" json:"pocket_list_items_rewilding_detail,omitempty"`
 }

--- a/internal/models/rewilding.go
+++ b/internal/models/rewilding.go
@@ -10,6 +10,8 @@ type Rewilding struct {
 	RewildingTypeData      RefRewildingTypes  `bson:"rewilding_type_data,omitempty" json:"rewilding_type_data"`
 	RewildingCity          string             `bson:"rewilding_city,omitempty" json:"rewilding_city"`
 	RewildingArea          string             `bson:"rewilding_area,omitempty" json:"rewilding_area"`
+	RewildingLocation      []string           `bson:"rewilding_location,omitempty" json:"rewilding_location"`
+	RewildingCountryCode   string             `bson:"rewilding_country_code,omitempty" json:"rewilding_country_code,omitempty"`
 	RewildingName          string             `bson:"rewilding_name,omitempty" json:"rewilding_name"`
 	RewildingRating        int                `bson:"rewilding_rating,omitempty" json:"rewilding_rating"`
 	RewildingLat           float64            `bson:"rewilding_lat,omitempty" json:"rewilding_lat"`

--- a/internal/models/userBadges.go
+++ b/internal/models/userBadges.go
@@ -6,5 +6,6 @@ type UserBadges struct {
 	UserBadgesId        primitive.ObjectID `bson:"_id,omitempty" json:"user_badges_id"`
 	UserBadgesUser      primitive.ObjectID `bson:"user_badges_user,omitempty" json:"user_badges_user"`
 	UserBadgesBadge     primitive.ObjectID `bson:"user_badges_badge,omitempty" json:"user_badges_badge"`
+	UserBadgesRewilding primitive.ObjectID `bson:"user_badges_rewilding,omitempty" json:"user_badges_rewilding"`
 	UserBadgesCreatedAt primitive.DateTime `bson:"user_badges_created_at,omitempty" json:"user_badges_created_at"`
 }

--- a/pkg/repository/collaborativeLogPolaroidRepository.go
+++ b/pkg/repository/collaborativeLogPolaroidRepository.go
@@ -164,8 +164,8 @@ func (r CollaborativeLogPolaroidRepository) Create(c *gin.Context) {
 	insert := models.EventPolaroids{
 		EventPolaroidsEvent:     Events.EventsId,
 		EventPolaroidsUrl:       fileName,
-		EventPolaroidsLat:       helpers.FloatToDecimal128(lat),
-		EventPolaroidsLng:       helpers.FloatToDecimal128(lng),
+		EventPolaroidsLat:       lat,
+		EventPolaroidsLng:       lng,
 		EventPolaroidsCreatedBy: userDetail.UsersId,
 		EventPolaroidsCreatedAt: primitive.NewDateTimeFromTime(time.Now()),
 	}

--- a/pkg/repository/eventRepository.go
+++ b/pkg/repository/eventRepository.go
@@ -187,6 +187,10 @@ func (r EventRepository) Create(c *gin.Context) {
 		EventParticipantsCreatedAt: primitive.NewDateTimeFromTime(time.Now()),
 	}
 	config.DB.Collection("EventParticipants").InsertOne(context.TODO(), insertParticipant)
+
+	// Create badge record
+	helpers.BadgeEvents(c, Events.EventsId)
+
 	c.JSON(http.StatusOK, Events)
 }
 

--- a/pkg/repository/pocketListRepository.go
+++ b/pkg/repository/pocketListRepository.go
@@ -109,7 +109,6 @@ func (r PocketListRepository) ReadOne(c *gin.Context, PocketList *models.PocketL
 }
 
 func (r PocketListRepository) ReadById(c *gin.Context, PocketList *models.PocketLists, id primitive.ObjectID) error {
-	fmt.Println("ReadById", id)
 	filter := bson.D{{Key: "_id", Value: id}}
 	err := config.DB.Collection("PocketLists").FindOne(context.TODO(), filter).Decode(&PocketList)
 	if err != nil {

--- a/pkg/repository/rewildingPhotoRepository.go
+++ b/pkg/repository/rewildingPhotoRepository.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"fmt"
 	"oosa_rewild/internal/config"
 	"oosa_rewild/internal/helpers"
 	"oosa_rewild/internal/models"
@@ -39,7 +38,7 @@ func (r RewildingPhotoRepository) Read(c *gin.Context) {
 	id, _ := primitive.ObjectIDFromHex(c.Param("id"))
 	photosId, _ := primitive.ObjectIDFromHex(c.Param("photosId"))
 	var Rewilding models.Rewilding
-	fmt.Println(photosId)
+
 	filter := bson.D{
 		{Key: "_id", Value: id},
 		{Key: "rewilding_photos._id", Value: photosId},

--- a/pkg/repository/testRepository.go
+++ b/pkg/repository/testRepository.go
@@ -9,7 +9,7 @@ import (
 type TestRepository struct{}
 
 func (r TestRepository) CreateBadge(c *gin.Context) {
-	helpers.BadgeAllocate(c, "R2")
+	// helpers.BadgeAllocate(c, "R2")
 }
 
 func (r TestRepository) CreateNotification(c *gin.Context) {


### PR DESCRIPTION
* Initial push

Initial push

* Cloudflare, fixes in Event

* Changes to event and collaborative log

* Update to datetime to use RFC3339

* Changes to events route

* Changes to event related objects

* FormData Implementation

Event and rewilding image upload. Show created by detail on events and rewilding

* 1.1.0

* 1.1.1

* 1.1.2

- Removal of duplicated reference endpoint in rewilding and event in favour for one general references endpoint
- Changes in datatype for Lat and Lng fields
- Removal of POST rewilding-register

* 1.1.3

- Changes in validation errorlist
- Changes in unauthorized HTTP Code 401 Unauthorised
- Pocket list - Count on move/delete item
- Pocket list - Join on rewilding to get detail
- Pocket List - Location info on rewilding
- Rewilding Search - Water type