### PR TITLE
1.1.5 (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# CHANGELOG 1.1.5
+## Changes
+- Default type ["national_park", "hiking_area", "campground", "camping_cabin", "park", "playground"] (GET rewilding-search)
+- Addition of event_meeting_point_name (POST event | PUT event/{id})
+- ⁠Pocket List, Reference link as array (POST rewilding)
+- ⁠Adjust event_participants object (GET event | my/event)
+- Removal of rewilding_type (GET rewilding)
+- Clear unnecessary fmt.Println
+
 # CHANGELOG 1.1.4
 ## Changes
 - Handling of breathing points on participation to event

--- a/internal/helpers/badges.go
+++ b/internal/helpers/badges.go
@@ -32,7 +32,6 @@ func BadgeAllocate(c *gin.Context, badgeCode string, badgeSource int, badgeRefer
 		config.DB.Collection("UserBadges").FindOne(context.TODO(), filter).Decode(&UserBadges)
 
 		if !MongoZeroID(UserBadges.UserBadgesId) {
-			fmt.Println("This badge is only received once")
 			return
 		}
 	}
@@ -62,7 +61,5 @@ func BadgeDetail(badgeCode string) models.Badges {
 }
 
 func BadgeEvents(c *gin.Context, eventId primitive.ObjectID) {
-	userDetail := GetAuthUser(c)
-	fmt.Println(userDetail)
 	BadgeAllocate(c, "N1", BADGE_REWILDING, eventId)
 }

--- a/internal/helpers/geocoding.go
+++ b/internal/helpers/geocoding.go
@@ -50,8 +50,6 @@ func GoogleMapsElevation(c *gin.Context, lat float64, lng float64) maps.Elevatio
 }
 
 func Haversine(lat1 float64, lon1 float64, lat2 float64, lon2 float64) float64 {
-
-	fmt.Println(lat1, lon1, lat2, lon2)
 	var R float64 = 6371
 	var x1 = lat2 - lat1
 	dLat := toRad(x1)

--- a/internal/helpers/rewild.go
+++ b/internal/helpers/rewild.go
@@ -2,7 +2,6 @@ package helpers
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"net/http"
 	"oosa_rewild/internal/config"
@@ -40,7 +39,6 @@ func RewildSaveGooglePhotos(c *gin.Context, photos []*places.GoogleMapsPlacesV1P
 		defer resp.Body.Close()
 
 		data, _ := io.ReadAll(resp.Body)
-		fmt.Println(data)
 
 		RwPhoto := models.RewildingPhotos{
 			RewildingPhotosID:   primitive.NewObjectID(),

--- a/internal/models/events.go
+++ b/internal/models/events.go
@@ -3,35 +3,41 @@ package models
 import "go.mongodb.org/mongo-driver/bson/primitive"
 
 type Events struct {
-	EventsId                   primitive.ObjectID `bson:"_id,omitempty" json:"events_id"`
-	EventsDate                 primitive.DateTime `bson:"events_date,omitempty" json:"events_date"`
-	EventsDateEnd              primitive.DateTime `bson:"events_date_end,omitempty" json:"events_date_end"`
-	EventsDeadline             primitive.DateTime `bson:"events_deadline,omitempty" json:"events_deadline"`
-	EventsName                 string             `bson:"events_name,omitempty" json:"events_name"`
-	EventsRewilding            primitive.ObjectID `bson:"events_rewilding,omitempty" json:"events_rewilding"`
-	EventsPlace                string             `bson:"events_place,omitempty" json:"events_place"`
-	EventsCityId               int                `bson:"events_city_id,omitempty" json:"events_city_id"`
-	EventsType                 string             `bson:"events_type,omitempty" json:"events_type,omitempty"`
-	EventsInvitationMessage    string             `bson:"events_invitation_message,omitempty" json:"events_invitation_message"`
-	EventsParticipantLimit     int                `bson:"events_participant_limit,omitempty" json:"events_participant_limit"`
-	EventsPaymentRequired      int                `bson:"events_payment_required,omitempty" json:"events_payment_required"`
-	EventsPaymentFee           float64            `bson:"events_payment_fee,omitempty" json:"events_payment_fee"`
-	EventsRequiresApproval     *int               `bson:"events_requires_approval,omitempty" json:"events_requires_approval"`
-	EventsQuestionnaireLink    string             `bson:"events_questionnaire_link,omitempty" json:"events_questionnaire_link"`
-	EventsLat                  float64            `bson:"events_lat,omitempty" json:"events_lat"`
-	EventsLng                  float64            `bson:"events_lng,omitempty" json:"events_lng"`
-	EventsMeetingPointLat      float64            `bson:"events_meeting_point_lat,omitempty" json:"events_meeting_point_lat"`
-	EventsMeetingPointLng      float64            `bson:"events_meeting_point_lng,omitempty" json:"events_meeting_point_lng"`
-	EventsStatisticTime        float64            `bson:"events_statistic_time,omitempty" json:"events_statistic_time"`
-	EventsStatisticDistance    float64            `bson:"events_statistic_distance,omitempty" json:"events_statistic_distance"`
-	EventsStatisticMemberCount int                `bson:"events_statistic_member_count,omitempty" json:"events_statistic_member_count"`
-	EventsPhoto                string             `bson:"events_photo,omitempty" json:"events_photo"`
-	EventsDeleted              *int               `bson:"events_deleted,omitempty" json:"events_deleted,omitempty"`
-	EventsDeletedAt            primitive.DateTime `bson:"events_deleted_at,omitempty" json:"events_deleted_at,omitempty"`
-	EventsCreatedBy            primitive.ObjectID `bson:"events_created_by,omitempty" json:"events_created_by"`
-	EventsCreatedAt            primitive.DateTime `bson:"events_created_at,omitempty" json:"events_created_at"`
-	EventsUpdatedBy            primitive.ObjectID `bson:"events_updated_by,omitempty" json:"events_updated_by"`
-	EventsUpdatedAt            primitive.DateTime `bson:"events_updated_at,omitempty" json:"events_updated_at"`
-	EventsParticipants         *[]UsersAgg        `bson:"events_participants,omitempty" json:"events_participants,omitempty"`
-	EventsCreatedByUser        *UsersAgg          `bson:"events_created_by_user,omitempty" json:"events_created_by_user,omitempty"`
+	EventsId                   primitive.ObjectID  `bson:"_id,omitempty" json:"events_id"`
+	EventsDate                 primitive.DateTime  `bson:"events_date,omitempty" json:"events_date"`
+	EventsDateEnd              primitive.DateTime  `bson:"events_date_end,omitempty" json:"events_date_end"`
+	EventsDeadline             primitive.DateTime  `bson:"events_deadline,omitempty" json:"events_deadline"`
+	EventsName                 string              `bson:"events_name,omitempty" json:"events_name"`
+	EventsRewilding            primitive.ObjectID  `bson:"events_rewilding,omitempty" json:"events_rewilding"`
+	EventsPlace                string              `bson:"events_place,omitempty" json:"events_place"`
+	EventsCityId               int                 `bson:"events_city_id,omitempty" json:"events_city_id"`
+	EventsType                 string              `bson:"events_type,omitempty" json:"events_type,omitempty"`
+	EventsInvitationMessage    string              `bson:"events_invitation_message,omitempty" json:"events_invitation_message"`
+	EventsParticipantLimit     int                 `bson:"events_participant_limit,omitempty" json:"events_participant_limit"`
+	EventsPaymentRequired      int                 `bson:"events_payment_required,omitempty" json:"events_payment_required"`
+	EventsPaymentFee           float64             `bson:"events_payment_fee,omitempty" json:"events_payment_fee"`
+	EventsRequiresApproval     *int                `bson:"events_requires_approval,omitempty" json:"events_requires_approval"`
+	EventsQuestionnaireLink    string              `bson:"events_questionnaire_link,omitempty" json:"events_questionnaire_link"`
+	EventsLat                  float64             `bson:"events_lat,omitempty" json:"events_lat"`
+	EventsLng                  float64             `bson:"events_lng,omitempty" json:"events_lng"`
+	EventsMeetingPointLat      float64             `bson:"events_meeting_point_lat,omitempty" json:"events_meeting_point_lat"`
+	EventsMeetingPointLng      float64             `bson:"events_meeting_point_lng,omitempty" json:"events_meeting_point_lng"`
+	EventsMeetingPointName     string              `bson:"events_meeting_point_name,omitempty" json:"events_meeting_point_name"`
+	EventsStatisticTime        float64             `bson:"events_statistic_time,omitempty" json:"events_statistic_time"`
+	EventsStatisticDistance    float64             `bson:"events_statistic_distance,omitempty" json:"events_statistic_distance"`
+	EventsStatisticMemberCount int                 `bson:"events_statistic_member_count,omitempty" json:"events_statistic_member_count"`
+	EventsPhoto                string              `bson:"events_photo,omitempty" json:"events_photo"`
+	EventsDeleted              *int                `bson:"events_deleted,omitempty" json:"events_deleted,omitempty"`
+	EventsDeletedAt            primitive.DateTime  `bson:"events_deleted_at,omitempty" json:"events_deleted_at,omitempty"`
+	EventsCreatedBy            primitive.ObjectID  `bson:"events_created_by,omitempty" json:"events_created_by"`
+	EventsCreatedAt            primitive.DateTime  `bson:"events_created_at,omitempty" json:"events_created_at"`
+	EventsUpdatedBy            primitive.ObjectID  `bson:"events_updated_by,omitempty" json:"events_updated_by"`
+	EventsUpdatedAt            primitive.DateTime  `bson:"events_updated_at,omitempty" json:"events_updated_at"`
+	EventsParticipants         EventParticipantObj `bson:"events_participants,omitempty" json:"events_participants,omitempty"`
+	EventsCreatedByUser        *UsersAgg           `bson:"events_created_by_user,omitempty" json:"events_created_by_user,omitempty"`
+}
+
+type EventParticipantObj struct {
+	LatestTreeUser *[]UsersAgg `json:"latest_tree_user"`
+	RemainNumber   int         `json:"remain_number"`
 }

--- a/internal/models/rewilding.go
+++ b/internal/models/rewilding.go
@@ -5,24 +5,23 @@ import (
 )
 
 type Rewilding struct {
-	RewildingID            primitive.ObjectID `bson:"_id,omitempty" json:"rewilding_id"`
-	RewildingType          primitive.ObjectID `bson:"rewilding_type,omitempty" json:"rewilding_type"`
-	RewildingTypeData      RefRewildingTypes  `bson:"rewilding_type_data,omitempty" json:"rewilding_type_data"`
-	RewildingCity          string             `bson:"rewilding_city,omitempty" json:"rewilding_city"`
-	RewildingArea          string             `bson:"rewilding_area,omitempty" json:"rewilding_area"`
-	RewildingLocation      []string           `bson:"rewilding_location,omitempty" json:"rewilding_location"`
-	RewildingCountryCode   string             `bson:"rewilding_country_code,omitempty" json:"rewilding_country_code,omitempty"`
-	RewildingName          string             `bson:"rewilding_name,omitempty" json:"rewilding_name"`
-	RewildingRating        int                `bson:"rewilding_rating,omitempty" json:"rewilding_rating"`
-	RewildingLat           float64            `bson:"rewilding_lat,omitempty" json:"rewilding_lat"`
-	RewildingLng           float64            `bson:"rewilding_lng,omitempty" json:"rewilding_lng"`
-	RewildingPlaceId       string             `bson:"rewilding_place_id,omitempty" json:"rewilding_place_id"`
-	RewildingElevation     float64            `bson:"rewilding_elevation,omitempty" json:"rewilding_elevation"`
-	RewildingPhotos        []RewildingPhotos  `bson:"rewilding_photos,omitempty" json:"rewilding_photos"`
-	RewildingApplyOfficial *bool              `bson:"rewilding_apply_official,default:false" json:"rewilding_apply_official"`
-	RewildingCreatedBy     primitive.ObjectID `bson:"rewilding_created_by,omitempty" json:"rewilding_created_by"`
-	RewildingCreatedAt     primitive.DateTime `bson:"rewilding_created_at,omitempty" json:"rewilding_created_at"`
-	RewildingCreatedByUser *UsersAgg          `bson:"rewilding_created_by_user,omitempty" json:"rewilding_created_by_user,omitempty"`
+	RewildingID             primitive.ObjectID        `bson:"_id,omitempty" json:"rewilding_id"`
+	RewildingCity           string                    `bson:"rewilding_city,omitempty" json:"rewilding_city"`
+	RewildingArea           string                    `bson:"rewilding_area,omitempty" json:"rewilding_area"`
+	RewildingLocation       []string                  `bson:"rewilding_location,omitempty" json:"rewilding_location"`
+	RewildingCountryCode    string                    `bson:"rewilding_country_code,omitempty" json:"rewilding_country_code,omitempty"`
+	RewildingName           string                    `bson:"rewilding_name,omitempty" json:"rewilding_name"`
+	RewildingRating         int                       `bson:"rewilding_rating,omitempty" json:"rewilding_rating"`
+	RewildingLat            float64                   `bson:"rewilding_lat,omitempty" json:"rewilding_lat"`
+	RewildingLng            float64                   `bson:"rewilding_lng,omitempty" json:"rewilding_lng"`
+	RewildingPlaceId        string                    `bson:"rewilding_place_id,omitempty" json:"rewilding_place_id"`
+	RewildingElevation      float64                   `bson:"rewilding_elevation,omitempty" json:"rewilding_elevation"`
+	RewildingPhotos         []RewildingPhotos         `bson:"rewilding_photos,omitempty" json:"rewilding_photos"`
+	RewildingReferenceLinks []RewildingReferenceLinks `bson:"rewilding_reference_links,omitempty" json:"rewilding_reference_links"`
+	RewildingApplyOfficial  *bool                     `bson:"rewilding_apply_official,default:false" json:"rewilding_apply_official"`
+	RewildingCreatedBy      primitive.ObjectID        `bson:"rewilding_created_by,omitempty" json:"rewilding_created_by"`
+	RewildingCreatedAt      primitive.DateTime        `bson:"rewilding_created_at,omitempty" json:"rewilding_created_at"`
+	RewildingCreatedByUser  *UsersAgg                 `bson:"rewilding_created_by_user,omitempty" json:"rewilding_created_by_user,omitempty"`
 }
 
 type RewildingPhotos struct {

--- a/internal/models/rewildingReferenceLinks.go
+++ b/internal/models/rewildingReferenceLinks.go
@@ -1,0 +1,6 @@
+package models
+
+type RewildingReferenceLinks struct {
+	RewildingReferenceLinksLink  string `bson:"rewilding_reference_links_link,omitempty" json:"rewilding_reference_links_link,omitempty"`
+	RewildingReferenceLinksTitle string `bson:"rewilding_reference_links_title,omitempty" json:"rewilding_reference_links_title,omitempty"`
+}

--- a/pkg/repository/cloudflareRepository.go
+++ b/pkg/repository/cloudflareRepository.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"log"
 	"mime/multipart"
@@ -53,9 +52,6 @@ func (r CloudflareRepository) Retrieve(c *gin.Context) {
 	}
 
 	req.Header.Set("Authorization", "Bearer "+config.APP.CloudflareImageAuthToken)
-
-	fmt.Println("Endpoint: " + endpoint)
-	fmt.Println("Bearer " + config.APP.CloudflareImageAuthToken)
 
 	// Create Response
 	resp, err := client.Do(req)
@@ -133,9 +129,6 @@ func (r CloudflareRepository) Post(c *gin.Context, file *multipart.FileHeader) (
 	req.Header.Set("Content-Type", writer.FormDataContentType())
 	req.Header.Set("Authorization", "Bearer "+config.APP.CloudflareImageAuthToken)
 
-	fmt.Println("Endpoint: " + endpoint)
-	fmt.Println("Bearer " + config.APP.CloudflareImageAuthToken)
-
 	// Create Response
 	resp, err := client.Do(req)
 	if err != nil {
@@ -151,9 +144,9 @@ func (r CloudflareRepository) Post(c *gin.Context, file *multipart.FileHeader) (
 
 	json.Unmarshal(body, &cloudflareResponse)
 
-	if cloudflareResponse.Success {
+	/*if cloudflareResponse.Success {
 		fmt.Println("SUCCESS!", cloudflareResponse.Result)
-	}
+	}*/
 
 	return cloudflareResponse, nil
 }

--- a/pkg/repository/eventInvitationRepository.go
+++ b/pkg/repository/eventInvitationRepository.go
@@ -26,7 +26,7 @@ func (r EventInvitationRepository) Retrieve(c *gin.Context) {
 		{Key: "event_participants_user", Value: userDetail.UsersId},
 		{Key: "event_participants_status", Value: GetEventParticipantStatus("PENDING")},
 	}
-	fmt.Println(filter)
+
 	cursor, err := config.DB.Collection("EventParticipants").Find(context.TODO(), filter)
 	cursor.All(context.TODO(), &results)
 

--- a/pkg/repository/eventScheduleRepository.go
+++ b/pkg/repository/eventScheduleRepository.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"net/http"
 	"oosa_rewild/internal/config"
@@ -157,7 +156,6 @@ func (r EventScheduleRepository) Create(c *gin.Context) {
 
 		for _, vSchedule := range v.Schedule {
 			fullDatetime := scheduleDate + "T" + vSchedule.EventSchedulesDatetime + "Z"
-			fmt.Println(fullDatetime)
 			scheduleTime := helpers.StringToDateTime(fullDatetime)
 
 			isValidDate := helpers.TimeIsBetween(scheduleTime, eventDateStart, eventDateEnd)
@@ -165,10 +163,6 @@ func (r EventScheduleRepository) Create(c *gin.Context) {
 			if !isValidDate {
 				errList = append(errList, scheduleDate+" "+vSchedule.EventSchedulesDatetime)
 			}
-			fmt.Println("isValidDate: ", isValidDate)
-			fmt.Println("scheduleTime: ", scheduleTime)
-			fmt.Println("eventDateStart: ", eventDateStart)
-			fmt.Println("eventDateEnd: ", eventDateEnd)
 
 			eventSchedule = append(eventSchedule, models.EventSchedules{
 				EventSchedulesEvent:       helpers.StringToPrimitiveObjId(c.Param("id")),

--- a/pkg/repository/pocketListItemsRepository.go
+++ b/pkg/repository/pocketListItemsRepository.go
@@ -97,7 +97,6 @@ func (r PocketListItemsRepository) Create(c *gin.Context) {
 		return
 	}
 
-	fmt.Println(result.InsertedID.(primitive.ObjectID))
 	data, err := helpers.GetPocketListItem(c, result.InsertedID.(primitive.ObjectID))
 
 	PocketListRepository{}.UpdateCount(c, pocketListId)

--- a/pkg/repository/pocketListRepository.go
+++ b/pkg/repository/pocketListRepository.go
@@ -133,12 +133,11 @@ func (r PocketListRepository) UpdateCount(c *gin.Context, pocketListId string) {
 	var PocketLists models.PocketLists
 	r.ReadOne(c, &PocketLists, pocketListId)
 
-	fmt.Println("UpdateCount:INIT")
 	opts := options.Count().SetHint("_id_")
 	filter := bson.D{{Key: "pocket_list_items_mst", Value: helpers.StringToPrimitiveObjId(pocketListId)}}
 	count, err := config.DB.Collection("PocketListItems").CountDocuments(context.TODO(), filter, opts)
 	if err != nil {
-		fmt.Println("UpdateCount", err.Error())
+		fmt.Println("ERROR", err.Error())
 	}
 
 	PocketLists.PocketListsCount = int(count)

--- a/pkg/repository/rewildingRegisterRepository.go
+++ b/pkg/repository/rewildingRegisterRepository.go
@@ -143,7 +143,6 @@ func (r RewildingRegisterRepository) ProcessData(c *gin.Context, Rewilding *mode
 	}
 
 	Rewilding.RewildingApplyOfficial = &rewildingApplyOfficial
-	Rewilding.RewildingType = helpers.StringToPrimitiveObjId(payload.RewildingType)
 	Rewilding.RewildingName = payload.RewildingName
 	Rewilding.RewildingLat = lat
 	Rewilding.RewildingLng = lng

--- a/pkg/repository/rewildingSearchRepository.go
+++ b/pkg/repository/rewildingSearchRepository.go
@@ -85,6 +85,10 @@ func (r RewildingSearchRepository) Retrieve(c *gin.Context) {
 		log.Fatalf("error %s", err)
 	}
 
+	if len(includedTypes) == 0 {
+		includedTypes = []string{"national_park", "hiking_area", "campground", "camping_cabin", "park", "playground"}
+	}
+
 	if reqSearch != "" {
 		// Search by keyword
 		req := places.GoogleMapsPlacesV1SearchTextRequest{
@@ -152,18 +156,10 @@ func (r RewildingSearchRepository) Create(c *gin.Context) {
 	location := helpers.GooglePlacesToLocationArray(geocode.AddressComponents)
 	area, _ := helpers.GooglePlacesGetArea(geocode.AddressComponents, "administrative_area_level_1")
 	_, countryCode := helpers.GooglePlacesGetArea(geocode.AddressComponents, "country")
-
-	/*Cache References*/
-	var RewildingTypeData models.RefRewildingTypes
-	typeId, _ := primitive.ObjectIDFromHex(payload.RewildingType)
-	config.DB.Collection("RefRewildingTypes").FindOne(context.TODO(), bson.D{{Key: "_id", Value: typeId}}).Decode(&RewildingTypeData)
-
 	rewildingApplyOfficial := false
 
 	insert := models.Rewilding{
 		RewildingApplyOfficial: &rewildingApplyOfficial,
-		RewildingType:          helpers.StringToPrimitiveObjId(payload.RewildingType),
-		RewildingTypeData:      RewildingTypeData,
 		RewildingCity:          payload.RewildingCity,
 		RewildingArea:          area,
 		RewildingLocation:      location,
@@ -210,17 +206,10 @@ func (r RewildingSearchRepository) Update(c *gin.Context) {
 	lat := payload.RewildingLat
 	lng := payload.RewildingLng
 
-	/*Cache References*/
-	var RewildingTypeData models.RefRewildingTypes
-	typeId, _ := primitive.ObjectIDFromHex(payload.RewildingType)
-	config.DB.Collection("RefRewildingTypes").FindOne(context.TODO(), bson.D{{Key: "_id", Value: typeId}}).Decode(&RewildingTypeData)
-
 	/*Find one*/
 	var Rewilding models.Rewilding
 	config.DB.Collection("Rewilding").FindOne(context.TODO(), bson.D{{Key: "_id", Value: id}}).Decode(&Rewilding)
 
-	Rewilding.RewildingType = helpers.StringToPrimitiveObjId(payload.RewildingType)
-	Rewilding.RewildingTypeData = RewildingTypeData
 	Rewilding.RewildingCity = payload.RewildingCity
 	Rewilding.RewildingArea = payload.RewildingArea
 	// Rewilding.RewildingLocation = []string{}

--- a/pkg/repository/userEventRepository.go
+++ b/pkg/repository/userEventRepository.go
@@ -75,68 +75,6 @@ func (r UserEventRepository) Retrieve(c *gin.Context) {
 		return
 	}
 
-	for k, v := range results {
-		var EventParticipantsUser []models.UsersAgg
-		var EventParticipants []models.EventParticipants
-
-		agg := mongo.Pipeline{
-			bson.D{{
-				Key: "$match", Value: bson.M{
-					"event_participants_event":  v.EventsId,
-					"event_participants_status": 1,
-				},
-			}},
-			bson.D{{
-				Key: "$lookup", Value: bson.M{
-					"from":         "Users",
-					"localField":   "event_participants_user",
-					"foreignField": "_id",
-					"as":           "event_participants_user_detail",
-				},
-			}},
-			bson.D{{
-				Key: "$unwind", Value: "$event_participants_user_detail",
-			}},
-		}
-		cursor, _ := config.DB.Collection("EventParticipants").Aggregate(context.TODO(), agg)
-		cursor.All(context.TODO(), &EventParticipants)
-
-		if len(EventParticipants) == 0 {
-			EventParticipantsUser = make([]models.UsersAgg, 0)
-		} else {
-			for _, vU := range EventParticipants {
-				EventParticipantsUser = append(EventParticipantsUser, *vU.EventParticipantsUserDetail)
-			}
-		}
-
-		results[k].EventsParticipants = &EventParticipantsUser
-	}
-
+	results = EventRepository{}.RetrieveParticipantDetails(results)
 	c.JSON(http.StatusOK, results)
 }
-
-/*
-
-db.Events.aggregate(
-    [
-		{
-			$lookup: {
-				from: "EventParticipants",
-				localField: "_id",
-				foreignField: "event_participants_event",
-				as: "EventParticipants"
-			}
-		},
-		{
-			$unwind: "$EventParticipants"
-		},
-		{
-			$match : {
-				"events_date": { $gte: ISODate("2024-06-01T00:00:00.000Z") },
-				"EventParticipants.event_participants_user" : ObjectId("6613fae21977170d4fd608a6")
-			}
-		}
-	]
-);
-
-*/


### PR DESCRIPTION
* Initial push

Initial push

* Cloudflare, fixes in Event

* Changes to event and collaborative log

* Update to datetime to use RFC3339

* Changes to events route

* Changes to event related objects

* FormData Implementation

Event and rewilding image upload. Show created by detail on events and rewilding

* 1.1.0

* 1.1.1

* 1.1.2

- Removal of duplicated reference endpoint in rewilding and event in favour for one general references endpoint
- Changes in datatype for Lat and Lng fields
- Removal of POST rewilding-register

* 1.1.3

- Changes in validation errorlist
- Changes in unauthorized HTTP Code 401 Unauthorised
- Pocket list - Count on move/delete item
- Pocket list - Join on rewilding to get detail
- Pocket List - Location info on rewilding
- Rewilding Search - Water type

* 1.1.4

- Handling of breathing points on participation to event
- Changes to schedule GET and POST structure to be the same
- Changes to Rewilding Create to use same service
- Show participants on user events
- Bugfix pocketlist create rewilding
- Removal of /auth routes as it does not belong to this project

* 1.1.5

- Default type ["national_park", "hiking_area", "campground", "camping_cabin", "park", "playground"] (GET rewilding-search)
- Addition of event_meeting_point_name (POST event | PUT event/{id})
- ⁠Pocket List, Reference link as array (POST rewilding)
- ⁠Adjust event_participants object (GET event | my/event)
- Removal of rewilding_type (GET rewilding)
- Clear unnecessary fmt.Println