### PR TITLE
1.1.8 (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# CHANGELOG 1.1.8
+- POST event/{id}/schedule one day event bug fix
+
 # CHANGELOG 1.1.7
 - POST/PUT event missing event type
 - Set events_participant_limit & events_payment_fee to 0

--- a/pkg/repository/eventScheduleRepository.go
+++ b/pkg/repository/eventScheduleRepository.go
@@ -132,6 +132,9 @@ func (r EventScheduleRepository) Create(c *gin.Context) {
 	eventSchedule := []interface{}{}
 
 	days := int(math.Ceil(Event.EventsDateEnd.Time().Sub(Event.EventsDate.Time()).Hours() / 24))
+	if days == 0 {
+		days = 1
+	}
 
 	if len(payload.EventSchedule) != days {
 		helpers.ResponseBadRequestError(c, "Schedule does not match number of days ("+strconv.Itoa(days)+")")


### PR DESCRIPTION
* Initial push

Initial push

* Cloudflare, fixes in Event

* Changes to event and collaborative log

* Update to datetime to use RFC3339

* Changes to events route

* Changes to event related objects

* FormData Implementation

Event and rewilding image upload. Show created by detail on events and rewilding

* 1.1.0

* 1.1.1

* 1.1.2

- Removal of duplicated reference endpoint in rewilding and event in favour for one general references endpoint
- Changes in datatype for Lat and Lng fields
- Removal of POST rewilding-register

* 1.1.3

- Changes in validation errorlist
- Changes in unauthorized HTTP Code 401 Unauthorised
- Pocket list - Count on move/delete item
- Pocket list - Join on rewilding to get detail
- Pocket List - Location info on rewilding
- Rewilding Search - Water type

* 1.1.4

- Handling of breathing points on participation to event
- Changes to schedule GET and POST structure to be the same
- Changes to Rewilding Create to use same service
- Show participants on user events
- Bugfix pocketlist create rewilding
- Removal of /auth routes as it does not belong to this project

* 1.1.5

- Default type ["national_park", "hiking_area", "campground", "camping_cabin", "park", "playground"] (GET rewilding-search)
- Addition of event_meeting_point_name (POST event | PUT event/{id})
- ⁠Pocket List, Reference link as array (POST rewilding)
- ⁠Adjust event_participants object (GET event | my/event)
- Removal of rewilding_type (GET rewilding)
- Clear unnecessary fmt.Println

* 1.1.6

- Changes to notifications

* 1.1.7

- POST/PUT event missing event type
- Set events_participant_limit & events_payment_fee to 0
- Fix PUT event/{id} response
- POST event/{id}/schedule request and response changes
- GET event/{id}/schedule response changes
- DELETE event/{id}/schedule implement
- DELETE rewilding/{rewildingId} implement

* 1.1.8

POST event/{id}/schedule one day event bug fix