### PR TITLE
fix: tab3-star-status bug

### DIFF
--- a/pkg/repository/collaborativeLogRepository.go
+++ b/pkg/repository/collaborativeLogRepository.go
@@ -16,6 +16,135 @@ import (
 
 type CollaborativeLogRepository struct{}
 
+// buildSortGroupExpression 構建排序群組的 MongoDB 表達式
+// 根據拍立得數量和事件日期決定排序分組
+func buildSortGroupExpression(currentTime primitive.DateTime) bson.M {
+	return bson.M{
+		"$switch": bson.M{
+			"branches": []bson.M{
+				// A. 已開放上傳且尚未上傳任何拍立得
+				{
+					"case": bson.M{
+						"$and": []interface{}{
+							bson.M{"$lte": []interface{}{
+								bson.M{"$dateTrunc": bson.M{"date": "$events_date_end", "unit": "day"}},
+								bson.M{"$dateTrunc": bson.M{"date": currentTime, "unit": "day"}},
+							}},
+							bson.M{"$eq": []interface{}{
+								"$user_polaroid_count",
+								0,
+							}},
+						},
+					},
+					"then": 0,
+				},
+				// B. 尚未開放上傳
+				{
+					"case": bson.M{
+						"$gt": []interface{}{
+							bson.M{"$dateTrunc": bson.M{"date": "$events_date_end", "unit": "day"}},
+							bson.M{"$dateTrunc": bson.M{"date": currentTime, "unit": "day"}},
+						},
+					},
+					"then": 1,
+				},
+				// C. 已上傳任何數量的拍立得
+				{
+					"case": bson.M{
+						"$gt": []interface{}{
+							"$user_polaroid_count",
+							0, // 修改為大於0
+						},
+					},
+					"then": 2,
+				},
+			},
+			"default": 3, // 其他情況
+		},
+	}
+}
+
+// buildCanViewDetailsExpression 構建是否可查看詳情的 MongoDB 表達式
+func buildCanViewDetailsExpression(currentTime primitive.DateTime) bson.M {
+	return bson.M{
+		"$lte": []interface{}{
+			bson.M{"$dateTrunc": bson.M{"date": "$events_date_end", "unit": "day"}},
+			bson.M{"$dateTrunc": bson.M{"date": currentTime, "unit": "day"}},
+		},
+	}
+}
+
+// buildUploadPolaroidsExpression 構建是否可上傳拍立得的 MongoDB 表達式
+func buildUploadPolaroidsExpression(currentTime primitive.DateTime) bson.M {
+	return bson.M{
+		"$and": []interface{}{
+			bson.M{"$lte": []interface{}{
+				bson.M{"$dateTrunc": bson.M{"date": "$events_date_end", "unit": "day"}},
+				bson.M{"$dateTrunc": bson.M{"date": currentTime, "unit": "day"}},
+			}},
+			bson.M{"$eq": []interface{}{
+				"$user_polaroid_count",
+				0, // 只有拍立得數量為0時才顯示上傳按鈕
+			}},
+		},
+	}
+}
+
+// buildEffectiveDateFields 構建有效日期欄位的 MongoDB 表達式
+func buildEffectiveDateFields() bson.M {
+	return bson.M{
+		"effective_primary_date": bson.M{
+			"$cond": bson.M{
+				"if":   bson.M{"$eq": bson.A{"$sort_group", 2}},
+				"then": "$events_date",     // 已上傳的，以行程開始日期優先排序
+				"else": "$events_date_end", // 未上傳的，以行程結束日期優先排序
+			},
+		},
+		"effective_secondary_date": bson.M{
+			"$cond": bson.M{
+				"if":   bson.M{"$eq": bson.A{"$sort_group", 2}},
+				"then": "$events_date_end",
+				"else": "$events_date",
+			},
+		},
+	}
+}
+
+// buildCommonAggregationStages 構建通用的聚合階段
+func buildCommonAggregationStages(currentTime primitive.DateTime, uploadPolaroids interface{}) []bson.D {
+	return []bson.D{
+		// 添加基本欄位
+		{{Key: "$addFields", Value: bson.M{
+			"can_view_details": buildCanViewDetailsExpression(currentTime),
+			"upload_polaroids": uploadPolaroids,
+			"sort_group":       buildSortGroupExpression(currentTime),
+		}}},
+		// 添加事件操作欄位
+		{{Key: "$addFields", Value: bson.M{
+			"events_actions": bson.M{
+				"can_view_details": "$can_view_details",
+				"upload_polaroids": "$upload_polaroids",
+			},
+		}}},
+		// 查找事件創建者資訊
+		{{Key: "$lookup", Value: bson.M{
+			"from":         "Users",
+			"localField":   "events_created_by",
+			"foreignField": "_id",
+			"as":           "events_created_by_user",
+		}}},
+		{{Key: "$unwind", Value: "$events_created_by_user"}},
+		// 添加有效日期欄位
+		{{Key: "$addFields", Value: buildEffectiveDateFields()}},
+		// 排序
+		{{Key: "$sort", Value: bson.M{
+			"sort_group":               1,
+			"effective_primary_date":   -1,
+			"effective_secondary_date": -1,
+		}}},
+	}
+}
+
 func (r CollaborativeLogRepository) Retrieve(c *gin.Context) {
 	authUserId := helpers.GetAuthUser(c).UsersId            // 查詢者id
 	userId := helpers.StringToPrimitiveObjId(c.Param("id")) // 被查詢者id
@@ -64,91 +193,36 @@ func (r CollaborativeLogRepository) Retrieve(c *gin.Context) {
 					"events_rewilding": rewildingId,
 				},
 			}},
-			bson.D{{Key: "$addFields", Value: bson.M{
-				"can_view_details": bson.M{
-					"$lte": []interface{}{
-						bson.M{"$dateTrunc": bson.M{"date": "$events_date_end", "unit": "day"}},
-						bson.M{"$dateTrunc": bson.M{"date": currentTime, "unit": "day"}},
-					},
-				},
-				"upload_polaroids": false, // 查看者他人行程，不顯示上傳拍立得按鈕
-				"sort_group": bson.M{
-					"$switch": bson.M{
-						"branches": []bson.M{
-							// A. 已開放上傳但尚未上傳
-							{
-								"case": bson.M{
-									"$and": []interface{}{
-										bson.M{"$lt": []interface{}{
-											bson.M{"$dateTrunc": bson.M{"date": "$events_date_end", "unit": "day"}},
-											bson.M{"$dateTrunc": bson.M{"date": currentTime, "unit": "day"}},
-										}},
-										bson.M{"$eq": []interface{}{bson.M{"$type": "$event_participants_star_type"}, "missing"}},
-									},
-								},
-								"then": 0,
-							},
-							// B. 尚未開放上傳
-							{
-								"case": bson.M{
-									"$gte": []interface{}{
-										bson.M{"$dateTrunc": bson.M{"date": "$events_date_end", "unit": "day"}},
-										bson.M{"$dateTrunc": bson.M{"date": currentTime, "unit": "day"}},
-									},
-								},
-								"then": 1,
-							},
-							// C. 已上傳
-							{
-								"case": bson.M{
-									"$ne": []interface{}{bson.M{"$type": "$event_participants_star_type"}, "missing"},
-								},
-								"then": 2,
-							},
-						},
-						"default": 3, // 其他情況
-					},
+			// 添加 lookup EventPolaroids 來計算該用戶的拍立得數量
+			bson.D{{Key: "$lookup", Value: bson.M{
+				"as":   "EventPolaroids",
+				"from": "EventPolaroids",
+				"let":  bson.M{"event_id": "$_id", "user_id": userId},
+				"pipeline": []bson.M{
+					{"$match": bson.M{
+						"$expr": bson.M{
+							"$and": bson.A{
+								bson.M{"$eq": bson.A{"$event_polaroids_event", "$$event_id"}},
+								bson.M{"$eq": bson.A{"$event_polaroids_created_by", "$$user_id"}},
+							}},
+					}},
+					{"$count": "total"},
 				},
 			}}},
+			// 計算 user_polaroid_count 欄位
 			bson.D{{Key: "$addFields", Value: bson.M{
-				"events_actions": bson.M{
-					"can_view_details": "$can_view_details",
-					"upload_polaroids": "$upload_polaroids",
-				},
-			}}},
-			bson.D{{
-				Key: "$lookup", Value: bson.M{
-					"from":         "Users",
-					"localField":   "events_created_by",
-					"foreignField": "_id",
-					"as":           "events_created_by_user",
-				},
-			}},
-			bson.D{{
-				Key: "$unwind", Value: "$events_created_by_user",
-			}},
-			bson.D{{Key: "$addFields", Value: bson.M{
-				"effective_primary_date": bson.M{
-					"$cond": bson.M{
-						"if":   bson.M{"$eq": bson.A{"$sort_group", 2}},
-						"then": "$events_date",     // 已上傳拍立的，以行程開始日期優先排序
-						"else": "$events_date_end", // 未上傳拍立的，以行程結束日期優先排序
+				"user_polaroid_count": bson.M{
+					"$ifNull": bson.A{
+						bson.M{"$arrayElemAt": bson.A{"$EventPolaroids.total", 0}},
+						0,
 					},
 				},
-				"effective_secondary_date": bson.M{
-					"$cond": bson.M{
-						"if":   bson.M{"$eq": bson.A{"$sort_group", 2}},
-						"then": "$events_date_end",
-						"else": "$events_date",
-					},
-				},
-			}}},
-			bson.D{{Key: "$sort", Value: bson.M{
-				"sort_group":               1,
-				"effective_primary_date":   -1,
-				"effective_secondary_date": -1,
 			}}},
 		}
+
+		// 新增共用的Stage，查看他人行程不顯示上傳拍立得按鈕
+		commonStages := buildCommonAggregationStages(currentTime, false)
+		agg = append(agg, commonStages...)
 
 		cursor, err := config.DB.Collection("EventParticipants").Aggregate(context.TODO(), agg)
 
@@ -179,106 +253,51 @@ func (r CollaborativeLogRepository) Retrieve(c *gin.Context) {
 			},
 		}}}
 
+		// 添加 lookup EventPolaroids 來計算該用戶的拍立得數量
+		lookupPolaroids := bson.D{{Key: "$lookup", Value: bson.M{
+			"as":   "EventPolaroids",
+			"from": "EventPolaroids",
+			"let":  bson.M{"event_id": "$_id", "user_id": authUserId},
+			"pipeline": []bson.M{
+				{"$match": bson.M{
+					"$expr": bson.M{
+						"$and": bson.A{
+							bson.M{"$eq": bson.A{"$event_polaroids_event", "$$event_id"}},
+							bson.M{"$eq": bson.A{"$event_polaroids_created_by", "$$user_id"}},
+						}},
+				}},
+				{"$count": "total"},
+			},
+		}}}
+
 		unwindStage := bson.D{
 			{Key: "$unwind", Value: "$EventParticipants"},
 		}
+
+		// 計算 user_polaroid_count 欄位
+		addPolaroidCountStage := bson.D{{Key: "$addFields", Value: bson.M{
+			"user_polaroid_count": bson.M{
+				"$ifNull": bson.A{
+					bson.M{"$arrayElemAt": bson.A{"$EventPolaroids.total", 0}},
+					0,
+				},
+			},
+		}}}
 
 		agg := mongo.Pipeline{
 			bson.D{{
 				Key: "$match", Value: filterEvent,
 			}},
 			lookupStage,
+			lookupPolaroids,
 			unwindStage,
-			bson.D{{Key: "$addFields", Value: bson.M{
-				"can_view_details": bson.M{
-					"$lte": []interface{}{
-						bson.M{"$dateTrunc": bson.M{"date": "$events_date_end", "unit": "day"}},
-						bson.M{"$dateTrunc": bson.M{"date": currentTime, "unit": "day"}},
-					},
-				},
-				"upload_polaroids": bson.M{
-					"$and": []interface{}{
-						bson.M{"$lte": []interface{}{
-							bson.M{"$dateTrunc": bson.M{"date": "$events_date_end", "unit": "day"}},
-							bson.M{"$dateTrunc": bson.M{"date": currentTime, "unit": "day"}},
-						}},
-						bson.M{"$eq": []interface{}{bson.M{"$type": "$EventParticipants.event_participants_star_type"}, "missing"}},
-					},
-				},
-				"sort_group": bson.M{
-					"$switch": bson.M{
-						"branches": []bson.M{
-							{
-								"case": bson.M{
-									"$and": []interface{}{
-										bson.M{"$lt": []interface{}{
-											bson.M{"$dateTrunc": bson.M{"date": "$events_date_end", "unit": "day"}},
-											bson.M{"$dateTrunc": bson.M{"date": currentTime, "unit": "day"}},
-										}},
-										bson.M{"$eq": []interface{}{bson.M{"$type": "$EventParticipants.event_participants_star_type"}, "missing"}},
-									},
-								},
-								"then": 0,
-							},
-							{
-								"case": bson.M{
-									"$gte": []interface{}{
-										bson.M{"$dateTrunc": bson.M{"date": "$events_date_end", "unit": "day"}},
-										bson.M{"$dateTrunc": bson.M{"date": currentTime, "unit": "day"}},
-									},
-								},
-								"then": 1,
-							},
-							{
-								"case": bson.M{
-									"$ne": []interface{}{bson.M{"$type": "$EventParticipants.event_participants_star_type"}, "missing"},
-								},
-								"then": 2,
-							},
-						},
-						"default": 3,
-					},
-				},
-			}}},
-			bson.D{{Key: "$addFields", Value: bson.M{
-				"events_actions": bson.M{
-					"can_view_details": "$can_view_details",
-					"upload_polaroids": "$upload_polaroids",
-				},
-			}}},
-			bson.D{{
-				Key: "$lookup", Value: bson.M{
-					"from":         "Users",
-					"localField":   "events_created_by",
-					"foreignField": "_id",
-					"as":           "events_created_by_user",
-				},
-			}},
-			bson.D{{
-				Key: "$unwind", Value: "$events_created_by_user",
-			}},
-			bson.D{{Key: "$addFields", Value: bson.M{
-				"effective_primary_date": bson.M{
-					"$cond": bson.M{
-						"if":   bson.M{"$eq": bson.A{"$sort_group", 2}},
-						"then": "$events_date",
-						"else": "$events_date_end",
-					},
-				},
-				"effective_secondary_date": bson.M{
-					"$cond": bson.M{
-						"if":   bson.M{"$eq": bson.A{"$sort_group", 2}},
-						"then": "$events_date_end",
-						"else": "$events_date",
-					},
-				},
-			}}},
-			bson.D{{Key: "$sort", Value: bson.M{
-				"sort_group":               1,
-				"effective_primary_date":   -1,
-				"effective_secondary_date": -1,
-			}}},
+			addPolaroidCountStage,
 		}
+
+		// 新增共用的Stage，查看自己的行程，依照顯示上傳拍立得按鈕的條件來決定
+		commonStages := buildCommonAggregationStages(currentTime, buildUploadPolaroidsExpression(currentTime))
+		agg = append(agg, commonStages...)
+
 		cursor, err := config.DB.Collection("Events").Aggregate(context.TODO(), agg)
 		cursor.All(context.TODO(), &results)
 


### PR DESCRIPTION
1. 活動參與者A上傳後，B就不能上傳了(上傳按鈕就消失了)：改以拍立得數量判斷按鈕顯示邏輯，避免star_type在活動共同參與者間的相依性問題
2. 排序不符合預期：修正錯誤的sorting_group邏輯
3. 重構共用的aggregation stage